### PR TITLE
Remove hard-coding of `/bin/logger` as location of logger

### DIFF
--- a/deploy/zimbra.sh
+++ b/deploy/zimbra.sh
@@ -41,7 +41,7 @@ zimbra_deploy() {
   /opt/zimbra/bin/zmcertmgr verifycrt comm "$_ckey" "$_ccert" "${_cca}.real" || return 1
 
   #if it verifies we can deploy it
-  $(which logger) -p local2.info NETWORK "Certificate has been Renewed for $_cdomain"
+  logger -p local2.info NETWORK "Certificate has been Renewed for $_cdomain"
   cp -f "$_ckey" /opt/zimbra/ssl/zimbra/commercial/commercial.key
   /opt/zimbra/bin/zmcertmgr deploycrt comm "$_ccert" "${_cca}.real" || return 1
   

--- a/deploy/zimbra.sh
+++ b/deploy/zimbra.sh
@@ -41,7 +41,7 @@ zimbra_deploy() {
   /opt/zimbra/bin/zmcertmgr verifycrt comm "$_ckey" "$_ccert" "${_cca}.real" || return 1
 
   #if it verifies we can deploy it
-  /bin/logger -p local2.info NETWORK "Certificate has been Renewed for $_cdomain"
+  $(which logger) -p local2.info NETWORK "Certificate has been Renewed for $_cdomain"
   cp -f "$_ckey" /opt/zimbra/ssl/zimbra/commercial/commercial.key
   /opt/zimbra/bin/zmcertmgr deploycrt comm "$_ccert" "${_cca}.real" || return 1
   


### PR DESCRIPTION
In my system, `/bin/logger` is in `/usr/bin/logger`. `$(which logger)` takes care of that.

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->